### PR TITLE
Break lines at 100 characters in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 sample-avro-alert
 #################
 
-This package provides information about, and utilties for working with, LSST alerts in `Apache Avro`_ format.
-In particular, it includes:
+This package provides information about, and utilties for working with, LSST alerts in `Apache
+Avro`_ format. In particular, it includes:
 
 - Alert schemas;
 - Examples of alert contents;
@@ -20,25 +20,28 @@ Schemas
 Alert schemas are located in the ``schema`` directory.
 
 Schemas are filed according to their version number, following a ``MAJOR.MINOR`` scheme.
-We maintain ``FORWARD_TRANSITIVE`` compatibility within a major version, per the `Confluent compatibility model`_.
-The latest version of the schema may always be found at ``schema/latest``.
 
-.. _Confluent compatibility model: https://docs.confluent.io/current/schema-registry/docs/avro.html#forward-compatibility
+We maintain ``FORWARD_TRANSITIVE`` compatibility within a major version, per the `Confluent
+compatibility model`_. The latest version of the schema may always be found at ``schema/latest``.
+
+.. _Confluent compatibility model:
+   https://docs.confluent.io/current/schema-registry/docs/avro.html#forward-compatibility
 
 Example Alert Contents
 ======================
 
-Example alert contents are provided in the ``sample_data`` directories included with the corresponding schema.
+Example alert contents are provided in the ``sample_data`` directories included with the
+corresponding schema.
 
 Utility Code
 ============
 
-All code is written in Python, and uses the `fastavro`_ library.
-Simulation code also requires `NumPy`_.
-Both of these may be installed using standard tooling (pip, Conda, etc).
+All code is written in Python, and uses the `fastavro`_ library. Simulation code also requires
+`NumPy`_. Both of these may be installed using standard tooling (pip, Conda, etc).
 
-Although this package contains multiple versions of the alert schema, this library code is only written and tested using the latest version (``schema/latest``) at present.
-Future versions of this package should offer wider compatibility.
+Although this package contains multiple versions of the alert schema, this library code is only
+written and tested using the latest version (``schema/latest``) at present. Future versions of this
+package should offer wider compatibility.
 
 Installation
 ------------
@@ -46,8 +49,7 @@ Installation
 Using EUPS
 ^^^^^^^^^^
 
-This package may be managed using `EUPS`_.
-Assuming EUPS is available on your system, simply::
+This package may be managed using `EUPS`_. Assuming EUPS is available on your system, simply::
 
   $ git clone https://github.com/lsst-dm/sample-avro-alert.git
   $ setup -r sample-avro-alert
@@ -57,8 +59,9 @@ Assuming EUPS is available on your system, simply::
 By Modifying your Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-After cloning, add the ``sample-avro-alert/python`` directory to your ``PYTHONPATH`` environment variable, and the ``sample-avro-alert/bin`` directory to your ``PATH`` environment variable.
-For example (using `Bash`_)::
+After cloning, add the ``sample-avro-alert/python`` directory to your ``PYTHONPATH`` environment
+variable, and the ``sample-avro-alert/bin`` directory to your ``PATH`` environment variable. For
+example (using `Bash`_)::
 
   $ git clone https://github.com/lsst-dm/sample-avro-alert.git
   $ export PYTHONPATH=$(pwd)/sample-avro-alert/python${PYTHONPATH:+:${PYTHONPATH}}
@@ -69,24 +72,35 @@ For example (using `Bash`_)::
 Library
 -------
 
-The ``lsst.alerts`` Python package provides a suite of routines for working with alerts in the Avro format.
+The ``lsst.alerts`` Python package provides a suite of routines for working with alerts in the Avro
+format.
 
 Command Line
 ------------
 
 ``bin/validateAvroRoundTrip.py`` demonstrates round-tripping a simple alert through the Avro system.
-Sample data is provided in the ``schema/latest/sample_data/alert.json`` file, or an alternative may be provided on the command line.
-Optionally, the path to binary data files to be included in the packet as “postage stamp” images may be provided.
-If the ``--print`` flag is given, the alert contents are printed to screen for sanity checking.
-The command will print a brief summary of the size of the data in various formats.
-Thus::
 
-   $ ./bin/validateAvroRoundTrip.py --input-data=./schema/latest/sample_data/alert.json --cutout-template=./examples/stamp-678.fits --cutout-difference=./examples/stamp-679.fits
+Sample data is provided in the ``schema/latest/sample_data/alert.json`` file, or an alternative may
+be provided on the command line.
+
+Optionally, the path to binary data files to be included in the packet as “postage stamp” images may
+be provided.
+
+If the ``--print`` flag is given, the alert contents are printed to screen for sanity checking. The
+command will print a brief summary of the size of the data in various formats. Thus::
+
+   $ ./bin/validateAvroRoundTrip.py \
+           --input-data=./schema/latest/sample_data/alert.json \
+           --cutout-template=./examples/stamp-678.fits \
+           --cutout-difference=./examples/stamp-679.fits
 
 ``bin/simulateAlerts.py`` writes simulated alert packets to disk in Avro format.
-The resultant data is schema compliant, but the simulations are not intended to be realistic: packets are populated with pseudorandom numbers.
-The number of visits per year (equivalent to the number of previous DIASources observed for each alert) and the number of alerts to simulate may be specified on the command line.
-Thus::
+
+The resultant data is schema compliant, but the simulations are not intended to be realistic:
+packets are populated with pseudorandom numbers.
+
+The number of visits per year (equivalent to the number of previous DIASources observed for each
+alert) and the number of alerts to simulate may be specified on the command line. Thus::
 
    $ ./bin/simulateAlerts.py --visits-per-year=100 --num-alerts=10 ./output_file.avro
 


### PR DESCRIPTION
This is a tediously minor change - I do virtually all my code reading/browsing/editing in emacs. This makes it much more pleasant to read the README in that environment. I made no changes to the text, this is just line breaks and whitespace.