### PR TITLE
DM-26175: Require fastavro<0.24 for pip installations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ license = GPLv3
 
 [options]
 install_requires =
-    fastavro
+    fastavro<0.24
     numpy
 packages =
     lsst.alert.packet


### PR DESCRIPTION
This is one part of DM-26175, it's not the whole story.