### PR TITLE
DM-39756: Switch from pkg_resources to importlib.resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,22 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build and install wheel
       run: |
         pip install virtualenv
         test/test_wheel_install.sh
-    # TODO: Add lint and test steps once we actually pass these tests. Crib from
-    # https://github.com/lsst/daf_butler/blob/main/.github/workflows/lint.yaml.
+    - name: Install pytest and fastavro (needed by tests)
+      run: |
+        pip install --upgrade pip
+        pip install pytest fastavro
+    - name: Ensure we have a usable version installed
+      run: |
+        pip install -e .
+    - name: run tests
+      run: |
+        pytest test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,11 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/lint.yaml@main

--- a/python/lsst/alert/packet/bin/simulateAlerts.py
+++ b/python/lsst/alert/packet/bin/simulateAlerts.py
@@ -23,7 +23,7 @@
 
 import argparse
 
-import fastavro
+import fastavro  # noqa: F401
 
 import lsst.alert.packet
 
@@ -48,12 +48,12 @@ def main():
                   'prvDiaForcedSources': args.visits_per_year//12,
                   'prvDiaNondetectionLimits': 0}
     alerts = [lsst.alert.packet.simulate_alert(schema.definition,
-                                        keepNull=['ssObject'],
-                                        arrayCount=arrayCount)
+                                               keepNull=['ssObject'],
+                                               arrayCount=arrayCount)
               for _ in range(args.num_alerts)]
 
     for alert in alerts:
-        assert(schema.validate(alert))
+        assert schema.validate(alert)
 
     with open(args.output_filename, "wb") as f:
         schema.store_alerts(f, alerts)
@@ -61,9 +61,9 @@ def main():
     with open(args.output_filename, "rb") as f:
         writer_schema, loaded_alerts = schema.retrieve_alerts(f)
 
-    assert(schema == writer_schema)
+    assert schema == writer_schema
     for a1, a2 in zip(alerts, loaded_alerts):
-        assert(a1 == a2)
+        assert a1 == a2
 
 
 if __name__ == '__main__':

--- a/python/lsst/alert/packet/bin/validateAvroRoundTrip.py
+++ b/python/lsst/alert/packet/bin/validateAvroRoundTrip.py
@@ -30,7 +30,6 @@ import argparse
 import filecmp
 import json
 import os
-import sys
 import tempfile
 
 import lsst.alert.packet
@@ -59,6 +58,7 @@ def check_file_round_trip(baseline, received_data):
             f.write(received_data)
         assert filecmp.cmp(baseline, filename, shallow=False)
 
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--schema-version', type=str,
@@ -74,6 +74,7 @@ def parse_args():
                         help='Pretty-print alert contents')
 
     return parser.parse_args()
+
 
 def main():
     args = parse_args()

--- a/python/lsst/alert/packet/bin/validateAvroRoundTrip.py
+++ b/python/lsst/alert/packet/bin/validateAvroRoundTrip.py
@@ -81,18 +81,18 @@ def main():
         schema_major, schema_minor = lsst.alert.packet.get_latest_schema_version()
     else:
         schema_major, schema_minor = args.schema_version.split(".")
-    schema_root = lsst.alert.packet.get_schema_path(schema_major, schema_minor)
 
-    alert_schema = lsst.alert.packet.Schema.from_file(
-        os.path.join(schema_root,
-                     schema_filename(schema_major, schema_minor)),
-    )
-    if args.input_data:
-        input_data = args.input_data
-    else:
-        input_data = os.path.join(schema_root, "sample_data", SAMPLE_FILENAME)
-    with open(input_data) as f:
-        json_data = json.load(f)
+    with lsst.alert.packet.get_schema_path(schema_major, schema_minor) as schema_root:
+        alert_schema = lsst.alert.packet.Schema.from_file(
+            os.path.join(schema_root,
+                         schema_filename(schema_major, schema_minor)),
+        )
+        if args.input_data:
+            input_data = args.input_data
+        else:
+            input_data = os.path.join(schema_root, "sample_data", SAMPLE_FILENAME)
+        with open(input_data) as f:
+            json_data = json.load(f)
 
     # Load difference stamp if included
     stamp_size = 0

--- a/python/lsst/alert/packet/io.py
+++ b/python/lsst/alert/packet/io.py
@@ -30,6 +30,7 @@ from .schema import Schema
 
 __all__ = ["load_stamp", "retrieve_alerts"]
 
+
 def load_stamp(file_path):
     """Load a cutout postage stamp file to include in alert.
     """
@@ -38,6 +39,7 @@ def load_stamp(file_path):
         cutout_data = f.read()
         cutout_dict = {"fileName": fileoutname, "stampData": cutout_data}
     return cutout_dict
+
 
 def retrieve_alerts(fp, reader_schema=None):
     """Read alert packets from the given I/O stream.
@@ -82,7 +84,8 @@ def retrieve_alerts(fp, reader_schema=None):
         first_record = next(reader)
         records = itertools.chain([first_record], reader)
     except StopIteration:
-        # The file has zero records in it. It might still have a schema, though.
+        # The file has zero records in it. It might still have a schema,
+        # though.
         records = []
     writer_schema = Schema(reader.writer_schema)
     return writer_schema, records

--- a/python/lsst/alert/packet/schema.py
+++ b/python/lsst/alert/packet/schema.py
@@ -22,10 +22,11 @@
 """Routines for working with Avro schemas.
 """
 
+import contextlib
 import io
 import os.path
-import pkg_resources
 from pathlib import PurePath
+from importlib import resources
 
 import fastavro
 
@@ -33,10 +34,22 @@ __all__ = ["get_schema_root", "get_latest_schema_version", "get_schema_path",
            "Schema", "get_path_to_latest_schema"]
 
 
+def _get_ref(*args):
+    """Return the package resource file path object.
+
+    Parameters are relative to lsst.alert.packet.
+    """
+    return resources.files("lsst.alert.packet").joinpath(*args)
+
+
+@contextlib.contextmanager
 def get_schema_root():
     """Return the root of the directory within which schemas are stored.
+
+    Returned as a context manager yielding the path to the root.
     """
-    return pkg_resources.resource_filename(__name__, "schema")
+    with resources.as_file(_get_ref("schema")) as f:
+        yield str(f)
 
 
 def get_latest_schema_version():
@@ -50,12 +63,14 @@ def get_latest_schema_version():
         The minor version number.
 
     """
-    val = pkg_resources.resource_string(__name__, "schema/latest.txt")
+    with _get_ref("schema", "latest.txt").open("rb") as fh:
+        val = fh.read()
     clean = val.strip()
     major, minor = clean.split(b".", 1)
     return int(major), int(minor)
 
 
+@contextlib.contextmanager
 def get_schema_path(major, minor):
     """Get the path to a package resource directory housing alert schema
     definitions.
@@ -73,13 +88,11 @@ def get_schema_path(major, minor):
         Path to the directory containing the schemas.
 
     """
-
-    # Note that as_posix() is right here, since pkg_resources
-    # always uses slash-delimited paths, even on Windows.
-    path = PurePath(f"schema/{major}/{minor}/")
-    return pkg_resources.resource_filename(__name__, path.as_posix())
+    with resources.as_file(_get_ref("schema", str(major), str(minor))) as f:
+        yield str(f)
 
 
+@contextlib.contextmanager
 def get_path_to_latest_schema():
     """Get the path to the primary schema file for the latest schema.
 
@@ -90,8 +103,8 @@ def get_path_to_latest_schema():
     """
 
     major, minor = get_latest_schema_version()
-    schema_path = PurePath(get_schema_path(major, minor))
-    return (schema_path / f"lsst.v{major}_{minor}.alert.avsc").as_posix()
+    with get_schema_path(major, minor) as schema_path:
+        yield (PurePath(schema_path) / f"lsst.v{major}_{minor}.alert.avsc").as_posix()
 
 
 def resolve_schema_definition(to_resolve, seen_names=None):
@@ -299,22 +312,24 @@ class Schema(object):
         Parameters
         ----------
         filename : `str`, optional
-            Path to the schema root (/path/to/lsst.vM_m.alert.avsc). 
-            Will recursively load referenced schemas, assuming they can be 
+            Path to the schema root (/path/to/lsst.vM_m.alert.avsc).
+            Will recursively load referenced schemas, assuming they can be
             found; otherwise, will raise. If `None` (the
             default), will load the latest schema defined in this package.
         """
         if filename is None:
             major, minor = get_latest_schema_version()
             root_name = f"lsst.v{major}_{minor}.alert"
-            filename = os.path.join(
-                get_schema_path(major, minor),
-                root_name + ".avsc",
-            )
+            with get_schema_path(major, minor) as schema_path:
+                filename = os.path.join(
+                    schema_path,
+                    root_name + ".avsc",
+                )
+                schema_definition = fastavro.schema.load_schema(filename)
         else:
             root_name = PurePath(filename).stem
+            schema_definition = fastavro.schema.load_schema(filename)
 
-        schema_definition = fastavro.schema.load_schema(filename)
         if hasattr(fastavro.schema._schema, 'SCHEMA_DEFS'):
             # Old fastavro gives a back a list if it recursively loaded more than one
             # file, otherwise a dict.

--- a/python/lsst/alert/packet/schema.py
+++ b/python/lsst/alert/packet/schema.py
@@ -307,7 +307,8 @@ class Schema(object):
 
     @classmethod
     def from_file(cls, filename=None):
-        """Instantiate a `Schema` by reading its definition from the filesystem.
+        """Instantiate a `Schema` by reading its definition from the
+        filesystem.
 
         Parameters
         ----------
@@ -331,8 +332,8 @@ class Schema(object):
             schema_definition = fastavro.schema.load_schema(filename)
 
         if hasattr(fastavro.schema._schema, 'SCHEMA_DEFS'):
-            # Old fastavro gives a back a list if it recursively loaded more than one
-            # file, otherwise a dict.
+            # Old fastavro gives a back a list if it recursively loaded more
+            # than one file, otherwise a dict.
             if isinstance(schema_definition, dict):
                 schema_definition = [schema_definition]
 

--- a/python/lsst/alert/packet/schemaRegistry.py
+++ b/python/lsst/alert/packet/schemaRegistry.py
@@ -137,13 +137,15 @@ class SchemaRegistry(object):
         """
         from .schema import Schema
         from .schema import get_schema_root
-        if not root:
-            root = get_schema_root()
-        registry = cls()
-        schema_root_file = schema_root + ".avsc"
-        for root, dirs, files in os.walk(root, followlinks=False):
-            if schema_root_file in files:
-                schema = Schema.from_file(os.path.join(root, schema_root_file))
-                version = ".".join(root.split("/")[-2:])
-                registry.register_schema(schema, version)
+
+        with get_schema_root() as default_root:
+            if not root:
+                root = default_root
+            registry = cls()
+            schema_root_file = schema_root + ".avsc"
+            for root, dirs, files in os.walk(root, followlinks=False):
+                if schema_root_file in files:
+                    schema = Schema.from_file(os.path.join(root, schema_root_file))
+                    version = ".".join(root.split("/")[-2:])
+                    registry.register_schema(schema, version)
         return registry

--- a/python/lsst/alert/packet/simulate.py
+++ b/python/lsst/alert/packet/simulate.py
@@ -27,35 +27,42 @@ import numpy
 
 __all__ = ["simulate_alert"]
 
+
 def randomNull():
     """Provide a random value of the Avro `null` type.
     """
     return None
+
 
 def randomBoolean():
     """Provide a random value of the Avro `boolean` type.
     """
     return random.choice([True, False])
 
+
 def randomInt():
     """Provide a random value of the Avro (32 bit, signed) `int` type.
     """
     return int(numpy.random.randint(-2**31, 2**31 - 1, dtype=numpy.int32))
+
 
 def randomLong():
     """Provide a random value of the Avro (64 bit, signed) `long` type.
     """
     return int(numpy.random.randint(-2**63, 2**63 - 1, dtype=numpy.int64))
 
+
 def randomFloat():
     """Provide a random value of the Avro (32) bit `float` type.
     """
     return float(numpy.float32(numpy.random.random()))
 
+
 def randomDouble():
     """Provide a random value of the Avro `double` type.
     """
     return float(numpy.float64(numpy.random.random()))
+
 
 def randomString():
     """Provide a random value of the Avro `string` type.
@@ -65,12 +72,14 @@ def randomString():
     return ''.join(random.choice(string.ascii_letters)
                    for _ in range(random.randint(0, 10)))
 
+
 def randomBytes(max_bytes=1000):
     """Provide a random value of the Avro `bytes` type.
 
     Up to `max_bytes` bytes are returned.
     """
     return numpy.random.bytes(random.randint(0, max_bytes))
+
 
 randomizerFunctionsByType = {
     'null': randomNull,
@@ -83,6 +92,7 @@ randomizerFunctionsByType = {
     'bytes': randomBytes
 }
 
+
 def simulate_alert(schema, keepNull=None, arrayCount=None):
     """Parse the schema and generate a compliant alert with random contents.
 
@@ -94,7 +104,8 @@ def simulate_alert(schema, keepNull=None, arrayCount=None):
     keepNull : {`list` of `str`, `None`}
         Schema keys for which to output null values.
     arrayCount : {`dict`, `None`}
-        Number of array items to randomly generate for each provided schema key.
+        Number of array items to randomly generate for each provided schema
+        key.
 
     Returns
     -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,11 @@ console_scripts =
     validateAvroRoundTrip.py = lsst.alert.packet.bin.validateAvroRoundTrip:main
     simulateAlerts.py = lsst.alert.packet.bin.simulateAlerts:main
     syncLatestSchemaToRegistry.py = lsst.alert.packet.bin.syncLatestSchemaToRegistry:main
+
+[flake8]
+max-line-length = 110
+max-doc-length = 79
+ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
+exclude =
+    __init__.py
+    doc/conf.py

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -43,11 +43,12 @@ class RetrieveAlertsTestCase(unittest.TestCase):
         """
         self.test_schema_version = get_latest_schema_version()
         self.test_schema = Schema.from_file()
-        sample_json_path = posixpath.join(
-            get_schema_path(*self.test_schema_version), "sample_data", "alert.json",
-        )
-        with open(sample_json_path, "r") as f:
-            self.sample_alert = json.load(f)
+        with get_schema_path(*self.test_schema_version) as schema_path:
+            sample_json_path = posixpath.join(
+                schema_path, "sample_data", "alert.json",
+            )
+            with open(sample_json_path, "r") as f:
+                self.sample_alert = json.load(f)
 
     def _mock_alerts(self, n):
         """Return a list of alerts with mock values, matching self.sample_alert.

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -24,7 +24,7 @@ import io
 import unittest
 import tempfile
 import posixpath
-import fastavro
+import fastavro  # noqa: F401
 import json
 from lsst.alert.packet.io import retrieve_alerts
 from lsst.alert.packet.schema import Schema
@@ -51,7 +51,8 @@ class RetrieveAlertsTestCase(unittest.TestCase):
                 self.sample_alert = json.load(f)
 
     def _mock_alerts(self, n):
-        """Return a list of alerts with mock values, matching self.sample_alert.
+        """Return a list of alerts with mock values, matching
+        self.sample_alert.
         """
         alerts = []
         for i in range(n):
@@ -61,21 +62,22 @@ class RetrieveAlertsTestCase(unittest.TestCase):
         return alerts
 
     def assert_alert_lists_equal(self, have_alerts, want_alerts):
-        """Assert that two lists of mock alerts are equal - or at least, equal enough.
+        """Assert that two lists of mock alerts are equal - or at least,
+        equal enough.
 
-        We can't naively do `self.assertEqual(have_alerts, want_alerts)` because
-        fastavro will explicitly populate an alert with "None" for every
-        optional field when deserializing it. The sample alert.json files don't
-        have those explicit Nones, and constructing them automatically seems
-        complex.
+        We can't naively do `self.assertEqual(have_alerts, want_alerts)`
+        because fastavro will explicitly populate an alert with "None" for
+        every optional field when deserializing it. The sample alert.json files
+        don't have those explicit Nones, and constructing them automatically
+        seems complex.
 
         A simple check is just that the two lists have the same length and that
-        the alertIds match. alertId is the only field that differs in a batch of
-        mock data created with self._mock_alerts, so this is probably
+        the alertIds match. alertId is the only field that differs in a batch
+        of mock data created with self._mock_alerts, so this is probably
         sufficient.
         """
         self.assertEqual(len(have_alerts), len(want_alerts))
-        for  i in range(len(have_alerts)):
+        for i in range(len(have_alerts)):
             self.assertEqual(
                 have_alerts[i]["alertId"], want_alerts[i]["alertId"],
                 f"alert idx={i} has mismatched IDs",
@@ -134,7 +136,8 @@ class RetrieveAlertsTestCase(unittest.TestCase):
         self.assertEqual(self.test_schema.definition, have_schema.definition)
 
     def test_alert_file_with_no_alerts(self):
-        """Write an alert file that contains no alerts at all. It should be readable.
+        """Write an alert file that contains no alerts at all. It should be
+        readable.
         """
         alerts = []
 

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -23,9 +23,9 @@ import os.path
 import unittest
 
 import fastavro
-import json
 
 from lsst.alert.packet import get_schema_root, Schema, get_path_to_latest_schema
+
 
 class SchemaRootTestCase(unittest.TestCase):
     """Test for get_schema_root().
@@ -48,12 +48,13 @@ class PathLatestSchemTestCase(unittest.TestCase):
 class ResolveTestCase(unittest.TestCase):
     """Test for schema resolution.
     """
+
     def test_recursive_resolve(self):
         """Check that resolution of nested schemas gives the expected result.
         """
         # Definition of schemas in terms of each other.
         named_schemas = {}
-        sub_sub_schema = fastavro.parse_schema({
+        sub_sub_schema = fastavro.parse_schema({  # noqa: F841
             "name": "subsub",
             "namespace": "lsst",
             "type": "record",
@@ -62,7 +63,7 @@ class ResolveTestCase(unittest.TestCase):
             ]
         }, named_schemas)
 
-        sub_schema = fastavro.parse_schema({
+        sub_schema = fastavro.parse_schema({  # noqa: F841
             "name": "sub",
             "namespace": "lsst",
             "type": "record",

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -32,7 +32,8 @@ class SchemaRootTestCase(unittest.TestCase):
     """
 
     def test_get_schema_root(self):
-        self.assertTrue(os.path.isdir(get_schema_root()))
+        with get_schema_root() as schema_root:
+            self.assertTrue(os.path.isdir(schema_root))
 
 
 class PathLatestSchemTestCase(unittest.TestCase):
@@ -40,7 +41,8 @@ class PathLatestSchemTestCase(unittest.TestCase):
     """
 
     def test_path_latest_schema(self):
-        self.assertTrue(os.path.isfile(get_path_to_latest_schema()))
+        with get_path_to_latest_schema() as schema_path:
+            self.assertTrue(os.path.isfile(schema_path))
 
 
 class ResolveTestCase(unittest.TestCase):

--- a/test/test_schemaRegistry.py
+++ b/test/test_schemaRegistry.py
@@ -26,6 +26,7 @@ from tempfile import TemporaryDirectory
 
 from lsst.alert.packet import SchemaRegistry
 
+
 def write_schema(root_dir, filename, version_major, version_minor):
     """Write a simple schema to a filesystem location based on its version.
     """
@@ -44,12 +45,14 @@ def write_schema(root_dir, filename, version_major, version_minor):
     with open(os.path.join(target_dir, filename), "w") as f:
         json.dump(schema, f)
 
+
 def create_filesystem_hierarchy(root_dir, root_file="lsst.example.avsc"):
     """Create a simple schema hierarchy on the filesystem.
     """
     write_schema(root_dir, root_file, "1", "0")
     write_schema(root_dir, root_file, "2", "0")
     write_schema(root_dir, root_file, "2", "1")
+
 
 class FromFilesystemTestCase(unittest.TestCase):
     """Demonstrate that the SchemaRegistry can work with on-disk data.

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -45,14 +45,15 @@ class SchemaValidityTestCase(unittest.TestCase):
         no_data = ("1.0",)  # No example data is available.
 
         for version in self.registry.known_versions:
-            path = path_to_sample_data(get_schema_root(), version, "alert.json")
-            schema = self.registry.get_by_version(version)
-            if version in no_data:
-                self.assertFalse(os.path.exists(path))
-            else:
-                with open(path, "r") as f:
-                    data = json.load(f)
-                self.assertTrue(self.registry.get_by_version(version).validate(data))
+            with get_schema_root() as schema_root:
+                path = path_to_sample_data(schema_root, version, "alert.json")
+                schema = self.registry.get_by_version(version)
+                if version in no_data:
+                    self.assertFalse(os.path.exists(path))
+                else:
+                    with open(path, "r") as f:
+                        data = json.load(f)
+                    self.assertTrue(self.registry.get_by_version(version).validate(data))
 
     def test_example_avro(self):
         """Test that example data in Avro format can be loaded by the schema.
@@ -61,27 +62,28 @@ class SchemaValidityTestCase(unittest.TestCase):
         bad_versions = ("2.0",)  # This data is known not to parse.
 
         for version in self.registry.known_versions:
-            path = path_to_sample_data(get_schema_root(), version,
-                                       "fakeAlert.avro")
-            schema = self.registry.get_by_version(version)
+            with get_schema_root() as schema_root:
+                path = path_to_sample_data(schema_root, version,
+                                        "fakeAlert.avro")
+                schema = self.registry.get_by_version(version)
 
-            if version in no_data:
-                self.assertFalse(os.path.exists(path))
-            else:
-                with open(path, "rb") as f:
-                    if version in bad_versions:
-                        with self.assertRaises(RuntimeError):
-                            schema.retrieve_alerts(f)
-                    else:
-                        retrieved_schema, alerts = schema.retrieve_alerts(f)
+                if version in no_data:
+                    self.assertFalse(os.path.exists(path))
+                else:
+                    with open(path, "rb") as f:
+                        if version in bad_versions:
+                            with self.assertRaises(RuntimeError):
+                                schema.retrieve_alerts(f)
+                        else:
+                            retrieved_schema, alerts = schema.retrieve_alerts(f)
 
-                        fastavro_keys = list(schema.definition.keys())
-                        for key in fastavro_keys:
-                            if '__' in key and '__len__' not in key:
-                                schema.definition.pop(key)
+                            fastavro_keys = list(schema.definition.keys())
+                            for key in fastavro_keys:
+                                if '__' in key and '__len__' not in key:
+                                    schema.definition.pop(key)
 
-                        self.assertEqual(retrieved_schema, schema,
-                                         f"schema not equal on version={version}")
-                        for idx, alert in enumerate(alerts):
-                            self.assertTrue(schema.validate(alert),
-                                            f"failed to validate version={version}, alert idx={idx}")
+                            self.assertEqual(retrieved_schema, schema,
+                                            f"schema not equal on version={version}")
+                            for idx, alert in enumerate(alerts):
+                                self.assertTrue(schema.validate(alert),
+                                                f"failed to validate version={version}, alert idx={idx}")

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -47,7 +47,7 @@ class SchemaValidityTestCase(unittest.TestCase):
         for version in self.registry.known_versions:
             with get_schema_root() as schema_root:
                 path = path_to_sample_data(schema_root, version, "alert.json")
-                schema = self.registry.get_by_version(version)
+                schema = self.registry.get_by_version(version)  # noqa: F841
                 if version in no_data:
                     self.assertFalse(os.path.exists(path))
                 else:
@@ -64,7 +64,7 @@ class SchemaValidityTestCase(unittest.TestCase):
         for version in self.registry.known_versions:
             with get_schema_root() as schema_root:
                 path = path_to_sample_data(schema_root, version,
-                                        "fakeAlert.avro")
+                                           "fakeAlert.avro")
                 schema = self.registry.get_by_version(version)
 
                 if version in no_data:
@@ -83,7 +83,7 @@ class SchemaValidityTestCase(unittest.TestCase):
                                     schema.definition.pop(key)
 
                             self.assertEqual(retrieved_schema, schema,
-                                            f"schema not equal on version={version}")
+                                             f"schema not equal on version={version}")
                             for idx, alert in enumerate(alerts):
                                 self.assertTrue(schema.validate(alert),
                                                 f"failed to validate version={version}, alert idx={idx}")


### PR DESCRIPTION
Given that resources can, in some rare cases, be inside zip files, I have implemented this as context managers rather than directly returning the paths. This required some tweaking in other places but @ebellm tells me this is an internal API.