### PR TITLE
DM-39756: Revert "Use importlib.resources"

### DIFF
--- a/python/lsst/alert/packet/bin/validateAvroRoundTrip.py
+++ b/python/lsst/alert/packet/bin/validateAvroRoundTrip.py
@@ -82,18 +82,18 @@ def main():
         schema_major, schema_minor = lsst.alert.packet.get_latest_schema_version()
     else:
         schema_major, schema_minor = args.schema_version.split(".")
+    schema_root = lsst.alert.packet.get_schema_path(schema_major, schema_minor)
 
-    with lsst.alert.packet.get_schema_path(schema_major, schema_minor) as schema_root:
-        alert_schema = lsst.alert.packet.Schema.from_file(
-            os.path.join(schema_root,
-                         schema_filename(schema_major, schema_minor)),
-        )
-        if args.input_data:
-            input_data = args.input_data
-        else:
-            input_data = os.path.join(schema_root, "sample_data", SAMPLE_FILENAME)
-        with open(input_data) as f:
-            json_data = json.load(f)
+    alert_schema = lsst.alert.packet.Schema.from_file(
+        os.path.join(schema_root,
+                     schema_filename(schema_major, schema_minor)),
+    )
+    if args.input_data:
+        input_data = args.input_data
+    else:
+        input_data = os.path.join(schema_root, "sample_data", SAMPLE_FILENAME)
+    with open(input_data) as f:
+        json_data = json.load(f)
 
     # Load difference stamp if included
     stamp_size = 0

--- a/python/lsst/alert/packet/schemaRegistry.py
+++ b/python/lsst/alert/packet/schemaRegistry.py
@@ -137,15 +137,13 @@ class SchemaRegistry(object):
         """
         from .schema import Schema
         from .schema import get_schema_root
-
-        with get_schema_root() as default_root:
-            if not root:
-                root = default_root
-            registry = cls()
-            schema_root_file = schema_root + ".avsc"
-            for root, dirs, files in os.walk(root, followlinks=False):
-                if schema_root_file in files:
-                    schema = Schema.from_file(os.path.join(root, schema_root_file))
-                    version = ".".join(root.split("/")[-2:])
-                    registry.register_schema(schema, version)
+        if not root:
+            root = get_schema_root()
+        registry = cls()
+        schema_root_file = schema_root + ".avsc"
+        for root, dirs, files in os.walk(root, followlinks=False):
+            if schema_root_file in files:
+                schema = Schema.from_file(os.path.join(root, schema_root_file))
+                version = ".".join(root.split("/")[-2:])
+                registry.register_schema(schema, version)
         return registry

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -43,12 +43,11 @@ class RetrieveAlertsTestCase(unittest.TestCase):
         """
         self.test_schema_version = get_latest_schema_version()
         self.test_schema = Schema.from_file()
-        with get_schema_path(*self.test_schema_version) as schema_path:
-            sample_json_path = posixpath.join(
-                schema_path, "sample_data", "alert.json",
-            )
-            with open(sample_json_path, "r") as f:
-                self.sample_alert = json.load(f)
+        sample_json_path = posixpath.join(
+            get_schema_path(*self.test_schema_version), "sample_data", "alert.json",
+        )
+        with open(sample_json_path, "r") as f:
+            self.sample_alert = json.load(f)
 
     def _mock_alerts(self, n):
         """Return a list of alerts with mock values, matching

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -32,8 +32,7 @@ class SchemaRootTestCase(unittest.TestCase):
     """
 
     def test_get_schema_root(self):
-        with get_schema_root() as schema_root:
-            self.assertTrue(os.path.isdir(schema_root))
+        self.assertTrue(os.path.isdir(get_schema_root()))
 
 
 class PathLatestSchemTestCase(unittest.TestCase):
@@ -41,8 +40,7 @@ class PathLatestSchemTestCase(unittest.TestCase):
     """
 
     def test_path_latest_schema(self):
-        with get_path_to_latest_schema() as schema_path:
-            self.assertTrue(os.path.isfile(schema_path))
+        self.assertTrue(os.path.isfile(get_path_to_latest_schema()))
 
 
 class ResolveTestCase(unittest.TestCase):

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -45,15 +45,14 @@ class SchemaValidityTestCase(unittest.TestCase):
         no_data = ("1.0",)  # No example data is available.
 
         for version in self.registry.known_versions:
-            with get_schema_root() as schema_root:
-                path = path_to_sample_data(schema_root, version, "alert.json")
-                schema = self.registry.get_by_version(version)  # noqa: F841
-                if version in no_data:
-                    self.assertFalse(os.path.exists(path))
-                else:
-                    with open(path, "r") as f:
-                        data = json.load(f)
-                    self.assertTrue(self.registry.get_by_version(version).validate(data))
+            path = path_to_sample_data(get_schema_root(), version, "alert.json")
+            schema = self.registry.get_by_version(version)  # noqa: F841
+            if version in no_data:
+                self.assertFalse(os.path.exists(path))
+            else:
+                with open(path, "r") as f:
+                    data = json.load(f)
+                self.assertTrue(self.registry.get_by_version(version).validate(data))
 
     def test_example_avro(self):
         """Test that example data in Avro format can be loaded by the schema.
@@ -62,28 +61,27 @@ class SchemaValidityTestCase(unittest.TestCase):
         bad_versions = ("2.0",)  # This data is known not to parse.
 
         for version in self.registry.known_versions:
-            with get_schema_root() as schema_root:
-                path = path_to_sample_data(schema_root, version,
-                                           "fakeAlert.avro")
-                schema = self.registry.get_by_version(version)
+            path = path_to_sample_data(get_schema_root(), version,
+                                       "fakeAlert.avro")
+            schema = self.registry.get_by_version(version)
 
-                if version in no_data:
-                    self.assertFalse(os.path.exists(path))
-                else:
-                    with open(path, "rb") as f:
-                        if version in bad_versions:
-                            with self.assertRaises(RuntimeError):
-                                schema.retrieve_alerts(f)
-                        else:
-                            retrieved_schema, alerts = schema.retrieve_alerts(f)
+            if version in no_data:
+                self.assertFalse(os.path.exists(path))
+            else:
+                with open(path, "rb") as f:
+                    if version in bad_versions:
+                        with self.assertRaises(RuntimeError):
+                            schema.retrieve_alerts(f)
+                    else:
+                        retrieved_schema, alerts = schema.retrieve_alerts(f)
 
-                            fastavro_keys = list(schema.definition.keys())
-                            for key in fastavro_keys:
-                                if '__' in key and '__len__' not in key:
-                                    schema.definition.pop(key)
+                        fastavro_keys = list(schema.definition.keys())
+                        for key in fastavro_keys:
+                            if '__' in key and '__len__' not in key:
+                                schema.definition.pop(key)
 
-                            self.assertEqual(retrieved_schema, schema,
-                                             f"schema not equal on version={version}")
-                            for idx, alert in enumerate(alerts):
-                                self.assertTrue(schema.validate(alert),
-                                                f"failed to validate version={version}, alert idx={idx}")
+                        self.assertEqual(retrieved_schema, schema,
+                                         f"schema not equal on version={version}")
+                        for idx, alert in enumerate(alerts):
+                            self.assertTrue(schema.validate(alert),
+                                            f"failed to validate version={version}, alert idx={idx}")


### PR DESCRIPTION
This reverts commit 84171147bcc000b56646246b400b6dc9b34cb3ec.

The schema file API is used as a public API so we can not change it the way we did by using a context manager.

Backs out #31.