### PR TITLE
DM-52273: Fix issue where empty cd will exit with error 

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -16,7 +16,12 @@ install() {
     cp -a ./ "$PREFIX"
     rm -rf "$PREFIX/ups"
     msg "Copied the product into '$PREFIX'"
-
+    
+    reldir="."
+        if [[ "$TAP_USE_BUILD_DIR" == 1 ]]; then
+            reldir=".."
+            cd "$BUILD_DIR"
+        fi
     cd "$reldir"
 
     install_ups


### PR DESCRIPTION
Due to changes in [The most recent POSIX specification](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/cd.html), a call to cd with an empty string will result in an error.