### PR TITLE
DM-46938: Add sdm_schemas to project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "numpy",
   "requests",
   "lsst-resources",
+  "lsst-sdm-schemas",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This adds `lsst-sdm-schemas` (sdm_schemas) to `pyproject.yaml`. It is already present in the EUPS table, so this normalizes the LSST dependencies.